### PR TITLE
Remove real Shopify API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ DATABASE_URL="file:./dev.db"
 SESSION_SECRET=your_session_secret_here
 ```
 
+> **Hinweis**: Hinterlege deine echten Shopify-Schlüssel über Secrets oder
+> Umgebungsvariablen, z.B. mit `fly secrets set SHOPIFY_API_KEY`.
+
 ### 3. Datenbank einrichten
 
 ```bash

--- a/deploy-now.sh
+++ b/deploy-now.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # Finales Deployment für shopify-billing-1751058813
-# Mit korrekter Client ID: f08ad740c5b93c05f8f188699eb5723c
+# Mit korrekter Client ID: YOUR_SHOPIFY_API_KEY
 
 set -e
 
 echo "🚀 Finales Deployment für shopify-billing-1751058813"
-echo "Client ID: f08ad740c5b93c05f8f188699eb5723c"
+echo "Client ID: YOUR_SHOPIFY_API_KEY"
 echo "=================================================="
 
 # Volume erstellen (falls nicht vorhanden)
@@ -16,7 +16,7 @@ flyctl volumes create data --size 1 --app shopify-billing-1751058813 || echo "�
 # Umgebungsvariablen mit echter Client ID setzen
 echo "🔐 Setze Umgebungsvariablen..."
 flyctl secrets set \
-    SHOPIFY_API_KEY="f08ad740c5b93c05f8f188699eb5723c" \
+    SHOPIFY_API_KEY="YOUR_SHOPIFY_API_KEY" \
     SHOPIFY_APP_URL="https://shopify-billing-1751058813.fly.dev" \
     SESSION_SECRET="$(openssl rand -base64 32)" \
     NODE_ENV="production" \

--- a/shopify.app.toml
+++ b/shopify.app.toml
@@ -1,7 +1,7 @@
 # Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 name = "Billing App"
-client_id = "f08ad740c5b93c05f8f188699eb5723c"
+client_id = "YOUR_SHOPIFY_API_KEY"
 application_url = "https://shopify-billing-1751058813.fly.dev"
 embedded = true
 


### PR DESCRIPTION
## Summary
- replace Shopify API key in shell script and config with placeholder
- document using secrets or environment variables for real keys

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm run typecheck` *(fails: numerous missing module type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68610c58c6848333a10728156982f29c