### PR TITLE
Update npm ci flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache openssl curl libc6-compat
 COPY package*.json ./
 
 # Install ALL dependencies (including devDependencies for build)
-RUN npm ci && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 
 # Copy source code
 COPY . .


### PR DESCRIPTION
## Summary
- update Dockerfile to use `npm ci --omit=dev`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68610c5378c4833396eaefda37cbd85f